### PR TITLE
Fixed bug: dns.resolve does not pass-through IPs ...

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -1,7 +1,7 @@
 module.exports = {
   title: "pimatic-ping device config schemas"
-  PingPresents: {
-    title: "PingPresents config options"
+  PingPresence: {
+    title: "PingPresence config options"
     type: "object"
     extensions: ["xLink", "xPresentLabel", "xAbsentLabel"]
     properties:


### PR DESCRIPTION
... as dns.lookup does. Now using net.isIP to bypass DNS query for IP addresses. This should fix the issue reported in forum topics http://forum.pimatic.org/topic/775/ping-plugin-used-with-computer-name and http://forum.pimatic.org/topic/1029/error-after-ping-plugin-update 

Fixed typo

See also: https://github.com/pimatic/pimatic/issues/724
