### PR TITLE
Fixed package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "GPL-2.0",
   "configSchema": "ping-config-schema.coffee",
   "dependencies": {
-    "net-ping": "git+https://github.com/mwittig/node-net-ping.git"
+    "net-ping": "^1.2.0"
   },
   "peerDependencies": {
     "pimatic": "0.8.*"


### PR DESCRIPTION
Updated package.json to use the NPM version of net-ping

On the raspberry pi net-ping wouldn't compile with the non-standard repo.
